### PR TITLE
Also trigger CI on pushes to "next" branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - next
 
 jobs:
   auto-release:


### PR DESCRIPTION
For seeing how prerelease handling works
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `0.2.4-next.0`

<details>
  <summary>Changelog</summary>

  #### 🏠 Internal
  
  - Also trigger CI on pushes to "next" branch [#22](https://github.com/jwodder/auto-test/pull/22) ([@jwodder](https://github.com/jwodder))
  
  #### 📝 Documentation
  
  - Add a missing prereq [#21](https://github.com/jwodder/auto-test/pull/21) ([@jwodder](https://github.com/jwodder))
  - Add TestPyPI link to README [#20](https://github.com/jwodder/auto-test/pull/20) ([@jwodder](https://github.com/jwodder))
  
  #### Authors: 1
  
  - John T. Wodder II ([@jwodder](https://github.com/jwodder))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
